### PR TITLE
fix: better element finding

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "countless",
     "description": "Don't like views on your Tweets? Remove it using countless!",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "manifest_version": 3,
     "icons": {
         "16": "logo.png",

--- a/script.js
+++ b/script.js
@@ -1,21 +1,18 @@
-const removeTags = () => {
-  var e1 = document.querySelectorAll("div.css-1dbjc4n.r-18u37iz.r-1h0z5md");
-  var e2 = document.querySelectorAll("div.css-1dbjc4n.r-1mf7evn");
-  e1 &&
-    e1.forEach((e) => {
-      if (e.childNodes[0].nodeName === "A") {
-        e.parentElement.removeChild(e);
-      }
-    });
-  e2 &&
-    e2.forEach((e) => {
-      if (
-        e?.childNodes[0]?.childNodes[0]?.nodeName === "A" &&
-        e?.childNodes[0]?.childNodes[0]?.href.toString().includes("/analytics")
-      ) {
-        e?.childNodes[0]?.parentElement.removeChild(e?.childNodes[0]);
-      }
-    });
-};
+function removeParentElement(element) {
+  if (element && element.parentNode) {
+    element.parentNode.removeChild(element);
+  }
+}
+
+function removeTags() {
+  const elements = document.querySelectorAll("[aria-label]");
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i];
+    const ariaLabel = element.getAttribute("aria-label");
+    if (ariaLabel && ariaLabel.includes("post analytics")) {
+      removeParentElement(element.parentNode);
+    }
+  }
+}
 
 setInterval(removeTags, 3000);


### PR DESCRIPTION
This update adds a better way to find DOM elements that contain the views info. Previously, it was based on finding using random classnames that were generated by Twitter's build tools that changed after every update to the site. Now, the extension finds elements using `aria-label` which doesn't change as frequently (if at all). This should prove a more reliable method of removing views from tweets.